### PR TITLE
Use different ports in testing to enable parallel tests

### DIFF
--- a/pkg/network/client_connection.go
+++ b/pkg/network/client_connection.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"knative.dev/pkg/logging"
@@ -33,7 +34,9 @@ type Dialer interface {
 }
 
 func StartControlClient(ctx context.Context, dialOptions Dialer, target string) (ctrl.Service, error) {
-	target = target + ":9000"
+	if !strings.Contains(target, ":") {
+		target = target + ":9000"
+	}
 	logging.FromContext(ctx).Infof("Starting control client to %s", target)
 
 	// Let's try the dial

--- a/pkg/reconciler/message_router_test.go
+++ b/pkg/reconciler/message_router_test.go
@@ -18,6 +18,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,15 +35,16 @@ func setupConnection(t *testing.T) (control.Service, control.Service) {
 	ctx := logging.WithLogger(context.TODO(), logger.Sugar())
 
 	dataPlane, connectionPool := setupInsecureServerAndConnectionPool(t, ctx)
+	address := fmt.Sprintf("127.0.0.1:%d", dataPlane.ListeningPort())
 
 	clientCtx, clientCancelFn := context.WithCancel(ctx)
 
-	conns, err := connectionPool.ReconcileConnections(clientCtx, "hello", []string{"127.0.0.1"}, nil, nil)
+	conns, err := connectionPool.ReconcileConnections(clientCtx, "hello", []string{address}, nil, nil)
 	require.NoError(t, err)
-	require.Contains(t, conns, "127.0.0.1")
+	require.Contains(t, conns, address)
 	t.Cleanup(clientCancelFn)
 
-	controlPlane := conns["127.0.0.1"]
+	controlPlane := conns[address]
 
 	return controlPlane, dataPlane
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fix #8