### PR TITLE
Renamed NotificationStore.ControlMessageHandler to NotificationStore.MessageHandler

### DIFF
--- a/pkg/reconciler/notification_store.go
+++ b/pkg/reconciler/notification_store.go
@@ -53,7 +53,7 @@ func NewNotificationStore(enqueueKey func(name types.NamespacedName), parser Pay
 	}
 }
 
-func (n *NotificationStore) ControlMessageHandler(srcName types.NamespacedName, pod string, valueMerger ValueMerger) control.MessageHandler {
+func (n *NotificationStore) MessageHandler(srcName types.NamespacedName, pod string, valueMerger ValueMerger) control.MessageHandler {
 	return control.MessageHandlerFunc(func(ctx context.Context, message control.ServiceMessage) {
 		// Parse the payload
 		parsedPayload, err := n.payloadParser(message.Payload())

--- a/pkg/reconciler/notification_store_test.go
+++ b/pkg/reconciler/notification_store_test.go
@@ -121,7 +121,7 @@ func setupNotificationStoreIntegrationTest(t *testing.T, merger reconciler.Value
 		enqueueKeyInvoked.Inc()
 	}, test.ParseMockMessage)
 
-	dataPlane.MessageHandler(notificationsStore.ControlMessageHandler(expectedNamespacedName, expectedPodIp, merger))
+	dataPlane.MessageHandler(notificationsStore.MessageHandler(expectedNamespacedName, expectedPodIp, merger))
 
 	return controlPlane, enqueueKeyInvoked, notificationsStore, expectedNamespacedName, expectedPodIp
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Renamed NotificationStore.ControlMessageHandler to NotificationStore.MessageHandler, leftover from the previous name of service message handler
