### PR TITLE
Joined InboundMessage and OutboundMessage under the same struct

### DIFF
--- a/pkg/connection.go
+++ b/pkg/connection.go
@@ -19,10 +19,10 @@ package control
 // Connection handles the low level stuff, reading and writing to the wire
 type Connection interface {
 	// OutboundMessages returns a channel that accepts the messages that goes on the wire
-	OutboundMessages() chan<- *OutboundMessage
+	OutboundMessages() chan<- *Message
 
 	// InboundMessages returns a channel that returns the inbound messages from the wire
-	InboundMessages() <-chan *InboundMessage
+	InboundMessages() <-chan *Message
 
 	// Errors returns a channel that signals very bad, usually fatal, errors
 	// (like cannot re-establish the connection after several attempts)

--- a/pkg/network/base_connection.go
+++ b/pkg/network/base_connection.go
@@ -34,16 +34,16 @@ type baseTcpConnection struct {
 	ctx    context.Context
 	logger *zap.SugaredLogger
 
-	outboundMessageChannel chan *ctrl.OutboundMessage
-	inboundMessageChannel  chan *ctrl.InboundMessage
+	outboundMessageChannel chan *ctrl.Message
+	inboundMessageChannel  chan *ctrl.Message
 	errors                 chan error
 }
 
-func (t *baseTcpConnection) OutboundMessages() chan<- *ctrl.OutboundMessage {
+func (t *baseTcpConnection) OutboundMessages() chan<- *ctrl.Message {
 	return t.outboundMessageChannel
 }
 
-func (t *baseTcpConnection) InboundMessages() <-chan *ctrl.InboundMessage {
+func (t *baseTcpConnection) InboundMessages() <-chan *ctrl.Message {
 	return t.inboundMessageChannel
 }
 
@@ -52,7 +52,7 @@ func (t *baseTcpConnection) Errors() <-chan error {
 }
 
 func (t *baseTcpConnection) read(conn net.Conn) error {
-	msg := &ctrl.InboundMessage{}
+	msg := &ctrl.Message{}
 	n, err := msg.ReadFrom(conn)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func (t *baseTcpConnection) read(conn net.Conn) error {
 	return nil
 }
 
-func (t *baseTcpConnection) write(conn net.Conn, msg *ctrl.OutboundMessage) error {
+func (t *baseTcpConnection) write(conn net.Conn, msg *ctrl.Message) error {
 	n, err := msg.WriteTo(conn)
 	if err != nil {
 		return err

--- a/pkg/network/base_connection_test.go
+++ b/pkg/network/base_connection_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -44,8 +45,8 @@ func TestBaseTcpConnection_ConsumeConnection_ReturnsAfterConnectionFailure(t *te
 	tcpConn := &baseTcpConnection{
 		ctx:                    ctx,
 		logger:                 logger.Sugar(),
-		outboundMessageChannel: make(chan *ctrl.OutboundMessage, 10),
-		inboundMessageChannel:  make(chan *ctrl.InboundMessage, 10),
+		outboundMessageChannel: make(chan *ctrl.Message, 10),
+		inboundMessageChannel:  make(chan *ctrl.Message, 10),
 		errors:                 make(chan error, 10),
 	}
 
@@ -85,8 +86,8 @@ func TestBaseTcpConnection_ConsumeConnection_ReturnsAfterContextClosed(t *testin
 	tcpConn := &baseTcpConnection{
 		ctx:                    ctx,
 		logger:                 logger.Sugar(),
-		outboundMessageChannel: make(chan *ctrl.OutboundMessage, 10),
-		inboundMessageChannel:  make(chan *ctrl.InboundMessage, 10),
+		outboundMessageChannel: make(chan *ctrl.Message, 10),
+		inboundMessageChannel:  make(chan *ctrl.Message, 10),
 		errors:                 make(chan error, 10),
 	}
 
@@ -125,15 +126,15 @@ func TestBaseTcpConnection_ConsumeConnection_BrokenConnectionDoesntLoseOutboundM
 	tcpConn := &baseTcpConnection{
 		ctx:                    ctx,
 		logger:                 logger.Sugar(),
-		outboundMessageChannel: make(chan *ctrl.OutboundMessage, 10),
-		inboundMessageChannel:  make(chan *ctrl.InboundMessage, 10),
+		outboundMessageChannel: make(chan *ctrl.Message, 10),
+		inboundMessageChannel:  make(chan *ctrl.Message, 10),
 		errors:                 make(chan error, 10),
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	msg := ctrl.NewOutboundMessage(10, nil)
+	msg := ctrl.NewMessage(uuid.New(), 10, nil)
 
 	go func() {
 		// This one should block

--- a/pkg/network/client_connection.go
+++ b/pkg/network/client_connection.go
@@ -82,8 +82,8 @@ func newClientTcpConnection(ctx context.Context, dialer Dialer) *clientTcpConnec
 		baseTcpConnection: baseTcpConnection{
 			ctx:                    ctx,
 			logger:                 logging.FromContext(ctx),
-			outboundMessageChannel: make(chan *ctrl.OutboundMessage, 10),
-			inboundMessageChannel:  make(chan *ctrl.InboundMessage, 10),
+			outboundMessageChannel: make(chan *ctrl.Message, 10),
+			inboundMessageChannel:  make(chan *ctrl.Message, 10),
 			errors:                 make(chan error, 10),
 		},
 		dialer: dialer,

--- a/pkg/network/server_connection.go
+++ b/pkg/network/server_connection.go
@@ -119,8 +119,8 @@ func newServerTcpConnection(ctx context.Context, listener net.Listener, tlsConfi
 		baseTcpConnection: baseTcpConnection{
 			ctx:                    ctx,
 			logger:                 logging.FromContext(ctx),
-			outboundMessageChannel: make(chan *ctrl.OutboundMessage, 10),
-			inboundMessageChannel:  make(chan *ctrl.InboundMessage, 10),
+			outboundMessageChannel: make(chan *ctrl.Message, 10),
+			inboundMessageChannel:  make(chan *ctrl.Message, 10),
 			errors:                 make(chan error, 10),
 		},
 		listener:        listener,

--- a/pkg/network/server_connection_test.go
+++ b/pkg/network/server_connection_test.go
@@ -44,8 +44,8 @@ func TestServerTcpConnection_CloseCtxCausesListenerToClose(t *testing.T) {
 		baseTcpConnection: baseTcpConnection{
 			ctx:                    ctx,
 			logger:                 logger.Sugar(),
-			outboundMessageChannel: make(chan *ctrl.OutboundMessage, 10),
-			inboundMessageChannel:  make(chan *ctrl.InboundMessage, 10),
+			outboundMessageChannel: make(chan *ctrl.Message, 10),
+			inboundMessageChannel:  make(chan *ctrl.Message, 10),
 			errors:                 make(chan error, 10),
 		},
 		listener: listener,

--- a/pkg/reconciler/pod_ip_getter_test.go
+++ b/pkg/reconciler/pod_ip_getter_test.go
@@ -89,7 +89,7 @@ func TestPodIpGetter_GetAllPodsIp(t *testing.T) {
 			}
 			got, err := ipGetter.GetAllPodsIp(namespace, labels.Everything())
 			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
+			require.ElementsMatch(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -26,11 +26,11 @@ type OpCode uint8
 const AckOpCode OpCode = 0
 
 type ServiceMessage struct {
-	inboundMessage *InboundMessage
+	inboundMessage *Message
 	ackFunc        func()
 }
 
-func NewServiceMessage(inboundMessage *InboundMessage, ackFunc func()) ServiceMessage {
+func NewServiceMessage(inboundMessage *Message, ackFunc func()) ServiceMessage {
 	return ServiceMessage{
 		inboundMessage: inboundMessage,
 		ackFunc:        ackFunc,

--- a/pkg/service/message_router_test.go
+++ b/pkg/service/message_router_test.go
@@ -40,7 +40,7 @@ func TestMessageRouter_HandleServiceMessage_Matching(t *testing.T) {
 		}),
 	})
 
-	inboundMsg := ctrl.NewInboundMessage(ctrl.ActualProtocolVersion, 0, 1, uuid.New(), nil)
+	inboundMsg := ctrl.NewMessage(uuid.New(), 1, nil, ctrl.WithFlags(0), ctrl.WithVersion(ctrl.ActualProtocolVersion))
 	require.False(t, svc.InvokeMessageHandler(context.TODO(), &inboundMsg))
 	require.Equal(t, int32(1), counter.Load())
 }
@@ -56,7 +56,7 @@ func TestMessageRouter_HandleServiceMessage_NotMatching(t *testing.T) {
 		}),
 	})
 
-	inboundMsg := ctrl.NewInboundMessage(ctrl.ActualProtocolVersion, 0, 10, uuid.New(), nil)
+	inboundMsg := ctrl.NewMessage(uuid.New(), 10, nil, ctrl.WithFlags(0), ctrl.WithVersion(ctrl.ActualProtocolVersion))
 	require.True(t, svc.InvokeMessageHandler(context.TODO(), &inboundMsg))
 	require.Equal(t, int32(0), counter.Load())
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -72,7 +72,7 @@ func (c *service) sendBinaryAndWaitForAck(opcode ctrl.OpCode, payload []byte) er
 	if opcode == ctrl.AckOpCode {
 		return fmt.Errorf("you cannot send an ack manually")
 	}
-	msg := ctrl.NewOutboundMessage(uint8(opcode), payload)
+	msg := ctrl.NewMessage(uuid.New(), uint8(opcode), payload)
 
 	logging.FromContext(c.ctx).Debugf("Going to send message with opcode %d and uuid %s", msg.OpCode(), msg.UUID().String())
 
@@ -137,7 +137,7 @@ func (c *service) startPolling() {
 	}()
 }
 
-func (c *service) accept(msg *ctrl.InboundMessage) {
+func (c *service) accept(msg *ctrl.Message) {
 	if msg.OpCode() == uint8(ctrl.AckOpCode) {
 		// Propagate the ack
 		c.waitingAcksMutex.Lock()
@@ -172,6 +172,6 @@ func (c *service) acceptError(err error) {
 	c.errorHandlerMutex.RUnlock()
 }
 
-func newAckMessage(uuid [16]byte) ctrl.OutboundMessage {
-	return ctrl.NewOutboundMessageWithUUID(uuid, uint8(ctrl.AckOpCode), nil)
+func newAckMessage(uuid [16]byte) ctrl.Message {
+	return ctrl.NewMessage(uuid, uint8(ctrl.AckOpCode), nil)
 }

--- a/pkg/service/service_caching_wrapper_test.go
+++ b/pkg/service/service_caching_wrapper_test.go
@@ -50,7 +50,7 @@ func TestCachingService(t *testing.T) {
 	require.Equal(t, uint8(10), outboundMessage.OpCode())
 	require.Equal(t, uint32(len([]byte(test.SomeMockPayload))), outboundMessage.Length())
 
-	inboundMessage := control.NewInboundMessage(control.ActualProtocolVersion, 0, uint8(control.AckOpCode), outboundMessage.UUID(), nil)
+	inboundMessage := control.NewMessage(outboundMessage.UUID(), uint8(control.AckOpCode), nil)
 	mockConnection.InboundCh <- &inboundMessage
 
 	wg.Wait()

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -53,7 +53,7 @@ func TestService_SendAndWaitForAck(t *testing.T) {
 	require.Equal(t, uint8(10), outboundMessage.OpCode())
 	require.Equal(t, uint32(len([]byte(test.SomeMockPayload))), outboundMessage.Length())
 
-	inboundMessage := ctrl.NewInboundMessage(ctrl.ActualProtocolVersion, 0, uint8(ctrl.AckOpCode), outboundMessage.UUID(), nil)
+	inboundMessage := ctrl.NewMessage(outboundMessage.UUID(), uint8(ctrl.AckOpCode), nil)
 
 	mockConnection.InboundCh <- &inboundMessage
 
@@ -80,7 +80,7 @@ func TestService_MessageHandler(t *testing.T) {
 	}))
 
 	msgUuid := uuid.New()
-	inboundMessage := ctrl.NewInboundMessage(ctrl.ActualProtocolVersion, 0, uint8(10), msgUuid, []byte(test.SomeMockPayload))
+	inboundMessage := ctrl.NewMessage(msgUuid, uint8(10), []byte(test.SomeMockPayload))
 	mockConnection.InboundCh <- &inboundMessage
 
 	wg.Wait()

--- a/pkg/test/connection_mock.go
+++ b/pkg/test/connection_mock.go
@@ -19,24 +19,24 @@ package test
 import control "knative.dev/control-protocol/pkg"
 
 type ConnectionMock struct {
-	OutboundCh chan *control.OutboundMessage
-	InboundCh  chan *control.InboundMessage
+	OutboundCh chan *control.Message
+	InboundCh  chan *control.Message
 	ErrorsCh   chan error
 }
 
 func NewConnectionMock() *ConnectionMock {
 	return &ConnectionMock{
-		OutboundCh: make(chan *control.OutboundMessage, 10),
-		InboundCh:  make(chan *control.InboundMessage, 10),
+		OutboundCh: make(chan *control.Message, 10),
+		InboundCh:  make(chan *control.Message, 10),
 		ErrorsCh:   make(chan error, 10),
 	}
 }
 
-func (c *ConnectionMock) OutboundMessages() chan<- *control.OutboundMessage {
+func (c *ConnectionMock) OutboundMessages() chan<- *control.Message {
 	return c.OutboundCh
 }
 
-func (c *ConnectionMock) InboundMessages() <-chan *control.InboundMessage {
+func (c *ConnectionMock) InboundMessages() <-chan *control.Message {
 	return c.InboundCh
 }
 
@@ -44,8 +44,8 @@ func (c *ConnectionMock) Errors() <-chan error {
 	return c.ErrorsCh
 }
 
-func (c *ConnectionMock) ConsumeOutboundMessages() []*control.OutboundMessage {
-	var res []*control.OutboundMessage
+func (c *ConnectionMock) ConsumeOutboundMessages() []*control.Message {
+	var res []*control.Message
 	for {
 		select {
 		case msg, ok := <-c.OutboundCh:

--- a/pkg/test/service_mock.go
+++ b/pkg/test/service_mock.go
@@ -63,7 +63,7 @@ func (s *ServiceMock) ErrorHandler(handler control.ErrorHandler) {
 }
 
 // InvokeMessageHandler invokes the registered message handler and returns true if the message was acked back
-func (s *ServiceMock) InvokeMessageHandler(ctx context.Context, message *control.InboundMessage) bool {
+func (s *ServiceMock) InvokeMessageHandler(ctx context.Context, message *control.Message) bool {
 	acked := atomic.NewBool(false)
 	ackFn := func() {
 		acked.Store(true)


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: `InboundMessage` and `OutboundMessage` are the same struct, so I joined them under the same name: `Message`. This avoids some duplicated code