### PR TITLE
Use max uint8 as ack opcode

### DIFF
--- a/pkg/service.go
+++ b/pkg/service.go
@@ -23,7 +23,7 @@ import (
 
 type OpCode uint8
 
-const AckOpCode OpCode = 0
+const AckOpCode = OpCode(^uint8(0))
 
 type ServiceMessage struct {
 	inboundMessage *Message


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

- :broom: Use max uint8 as ack opcode. This values is less error prone, and allows to add more "special" opcodes at the end, more than at the beginning of uint8
