### PR TITLE
ServiceMessage.Ack now can propagate an error string back to the sender

### DIFF
--- a/pkg/message.go
+++ b/pkg/message.go
@@ -168,7 +168,11 @@ func NewMessage(uuid [16]byte, opcode uint8, payload []byte, opts ...MessageOpt)
 	return msg
 }
 
-func (msg *Message) ReadFrom(r io.Reader) (count int64, err error) {
+func (m Message) Payload() []byte {
+	return m.payload
+}
+
+func (m *Message) ReadFrom(r io.Reader) (count int64, err error) {
 	var b [24]byte
 	var n int
 	n, err = io.ReadAtLeast(io.LimitReader(r, 24), b[0:24], 24)
@@ -177,26 +181,26 @@ func (msg *Message) ReadFrom(r io.Reader) (count int64, err error) {
 		return count, err
 	}
 
-	msg.MessageHeader = messageHeaderFromBytes(b)
-	if msg.Length() != 0 {
+	m.MessageHeader = messageHeaderFromBytes(b)
+	if m.Length() != 0 {
 		// We need to read the payload
-		msg.payload = make([]byte, msg.Length())
-		n, err = io.ReadAtLeast(io.LimitReader(r, int64(msg.Length())), msg.payload, int(msg.Length()))
+		m.payload = make([]byte, m.Length())
+		n, err = io.ReadAtLeast(io.LimitReader(r, int64(m.Length())), m.payload, int(m.Length()))
 		count = count + int64(n)
 	}
 	return count, err
 }
 
-func (msg *Message) WriteTo(w io.Writer) (count int64, err error) {
-	n, err := msg.MessageHeader.WriteTo(w)
+func (m *Message) WriteTo(w io.Writer) (count int64, err error) {
+	n, err := m.MessageHeader.WriteTo(w)
 	count = count + n
 	if err != nil {
 		return count, err
 	}
 
-	if msg.payload != nil {
+	if m.payload != nil {
 		var n1 int
-		n1, err = w.Write(msg.payload)
+		n1, err = w.Write(m.payload)
 		count = count + int64(n1)
 	}
 	return count, err

--- a/pkg/service.go
+++ b/pkg/service.go
@@ -27,10 +27,10 @@ const AckOpCode OpCode = 0
 
 type ServiceMessage struct {
 	inboundMessage *Message
-	ackFunc        func()
+	ackFunc        func(err error)
 }
 
-func NewServiceMessage(inboundMessage *Message, ackFunc func()) ServiceMessage {
+func NewServiceMessage(inboundMessage *Message, ackFunc func(err error)) ServiceMessage {
 	return ServiceMessage{
 		inboundMessage: inboundMessage,
 		ackFunc:        ackFunc,
@@ -47,7 +47,12 @@ func (c ServiceMessage) Payload() []byte {
 
 // Ack this message to the other end of the connection.
 func (c ServiceMessage) Ack() {
-	c.ackFunc()
+	c.ackFunc(nil)
+}
+
+// Ack this message to the other end of the connection, propagating an error while handling this message.
+func (c ServiceMessage) AckWithError(err error) {
+	c.ackFunc(err)
 }
 
 // MessageHandler is an error handler for ServiceMessage.

--- a/pkg/test/service_mock.go
+++ b/pkg/test/service_mock.go
@@ -65,7 +65,7 @@ func (s *ServiceMock) ErrorHandler(handler control.ErrorHandler) {
 // InvokeMessageHandler invokes the registered message handler and returns true if the message was acked back
 func (s *ServiceMock) InvokeMessageHandler(ctx context.Context, message *control.Message) bool {
 	acked := atomic.NewBool(false)
-	ackFn := func() {
+	ackFn := func(err error) {
 		acked.Store(true)
 	}
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- Thanks for sending a pull request! -->

# Changes

- :gift: Adds `Message.AckWithError` to propagate an error together with an ack. This is useful for synchronous commands use cases (as opposite of #47), when the fired command executes in a reasonable amount of time, hence letting the reconciler block for a very short amount of time.
