### PR TITLE
Fix port binding race

### DIFF
--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -175,7 +175,7 @@ func TestClientToServerWithServerDisconnection(t *testing.T) {
 	t.Cleanup(clientCancelFn)
 	t.Cleanup(serverCancelFn)
 
-	controlServer, err := network.StartControlServer(serverCtx, serverTLSConf)
+	controlServer, err := network.StartControlServer(serverCtx, serverTLSConf, network.WithPort(0))
 	require.NoError(t, err)
 
 	client, err := network.StartControlClient(clientCtx, clientTLSDialer, fmt.Sprintf("127.0.0.1:%d", controlServer.ListeningPort()))

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -111,7 +111,7 @@ func MustSetupSecureControlWithPool(t *testing.T, ctx context.Context, opts ...r
 
 	serverTlsConf, clientDialer := MustGenerateTestTLSConf(t, ctx)
 
-	server, err := network.StartControlServer(serverCtx, serverTlsConf)
+	server, err := network.StartControlServer(serverCtx, serverTlsConf, network.WithPort(0))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		serverCancelFn()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :bug: Fix port binding test race, which prevented servers to start because of binding to the same port.
