### PR TITLE
`Connection` interface doesn't use channels anymore

### DIFF
--- a/pkg/connection.go
+++ b/pkg/connection.go
@@ -16,13 +16,19 @@ limitations under the License.
 
 package control
 
+import "context"
+
 // Connection handles the low level stuff, reading and writing to the wire
 type Connection interface {
-	// OutboundMessages returns a channel that accepts the messages that goes on the wire
-	OutboundMessages() chan<- *Message
+	// WriteMessage writes a message to the wire.
+	// This blocks until the message is written to the wire.
+	// Returns ctx.Error() if the provided context is closed.
+	WriteMessage(ctx context.Context, msg *Message) error
 
-	// InboundMessages returns a channel that returns the inbound messages from the wire
-	InboundMessages() <-chan *Message
+	// ReadMessage reads a message from the wire.
+	// This blocks until there's a message available to read.
+	// Returns ctx.Error() if the provided context is closed.
+	ReadMessage(ctx context.Context) (*Message, error)
 
 	// Errors returns a channel that signals very bad, usually fatal, errors
 	// (like cannot re-establish the connection after several attempts)

--- a/pkg/network/base_connection.go
+++ b/pkg/network/base_connection.go
@@ -39,12 +39,23 @@ type baseTcpConnection struct {
 	errors                 chan error
 }
 
-func (t *baseTcpConnection) OutboundMessages() chan<- *ctrl.Message {
-	return t.outboundMessageChannel
+var _ ctrl.Connection = (*baseTcpConnection)(nil)
+
+func (t *baseTcpConnection) WriteMessage(ctx context.Context, msg *ctrl.Message) error {
+	t.outboundMessageChannel <- msg
+	return nil
 }
 
-func (t *baseTcpConnection) InboundMessages() <-chan *ctrl.Message {
-	return t.inboundMessageChannel
+func (t *baseTcpConnection) ReadMessage(ctx context.Context) (*ctrl.Message, error) {
+	select {
+	case msg, ok := <-t.inboundMessageChannel:
+		if !ok {
+			return nil, ctx.Err()
+		}
+		return msg, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func (t *baseTcpConnection) Errors() <-chan error {
@@ -118,7 +129,7 @@ func (t *baseTcpConnection) consumeConnection(conn net.Conn) {
 				}
 				err := t.write(conn, msg)
 				if err != nil {
-					t.outboundMessageChannel <- msg
+					t.WriteMessage(t.ctx, msg) // TODO
 
 					if isEOF(err) {
 						return // Closed conn

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -171,7 +171,9 @@ func (c *service) accept(msg *ctrl.Message) {
 	} else {
 		ackFunc := func(err error) {
 			ackMsg := newAckMessage(msg.UUID(), err)
-			_ = c.connection.WriteMessage(c.ctx, &ackMsg) // TODO what should we do with this error?
+			if err := c.connection.WriteMessage(c.ctx, &ackMsg); err != nil && err != c.ctx.Err() {
+				logging.FromContext(c.ctx).Warnf("Unexpected failure while acking back: %v", err)
+			}
 		}
 		c.handlerMutex.RLock()
 		c.handler.HandleServiceMessage(c.ctx, ctrl.NewServiceMessage(msg, ackFunc))


### PR DESCRIPTION
... but instead, it looks like a `Reader` and a `Writer` altogether.

The reason for this change is to simplify a **lot** of code and allow for more complex messaging constructs (like the broadcast issue explained at #66) without going through the pain of handling channels and their lifecycle.

This PR doesn't include the code simplification in the `network` package, because it would have required too much changes in a single PR. I will do that in the next PR.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Now the `Connection` interface looks like a `Reader` and a `Writer`