### PR TITLE
Add interfaces to ConnectionPool and AsyncNotificationStore for testing

### DIFF
--- a/pkg/reconciler/async_command_notification_store_test.go
+++ b/pkg/reconciler/async_command_notification_store_test.go
@@ -201,7 +201,7 @@ func TestAsyncCommand_Integration_Failure(t *testing.T) {
 	require.Equal(t, "failure", commandResult.Error)
 }
 
-func setupAsyncCommandNotificationStoreIntegrationTest(t *testing.T) (control.Service, *atomic.Int32, *reconciler.AsyncCommandNotificationStore, types.NamespacedName, string) {
+func setupAsyncCommandNotificationStoreIntegrationTest(t *testing.T) (control.Service, *atomic.Int32, reconciler.AsyncCommandNotificationStore, types.NamespacedName, string) {
 	expectedNamespacedName := types.NamespacedName{Namespace: "hello", Name: "world"}
 	expectedPodIp := "127.0.0.1"
 

--- a/pkg/reconciler/connection_pool_option.go
+++ b/pkg/reconciler/connection_pool_option.go
@@ -18,10 +18,10 @@ package reconciler
 
 import control "knative.dev/control-protocol/pkg"
 
-type ControlPlaneConnectionPoolOption func(*ControlPlaneConnectionPool)
+type ControlPlaneConnectionPoolOption func(*controlPlaneConnectionPoolImpl)
 
 func WithServiceWrapper(wrapper control.ServiceWrapper) ControlPlaneConnectionPoolOption {
-	return func(pool *ControlPlaneConnectionPool) {
+	return func(pool *controlPlaneConnectionPoolImpl) {
 		pool.serviceWrapperFactories = append(pool.serviceWrapperFactories, wrapper)
 	}
 }

--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -88,7 +88,7 @@ func (m *MockTLSDialerFactory) GenerateTLSDialer(*net.Dialer) (*tls.Dialer, erro
 	return (*tls.Dialer)(m), nil
 }
 
-func MustSetupInsecureControlWithPool(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, *reconciler.ControlPlaneConnectionPool) {
+func MustSetupInsecureControlWithPool(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, reconciler.ControlPlaneConnectionPool) {
 	serverCtx, serverCancelFn := context.WithCancel(ctx)
 
 	controlServer, err := network.StartInsecureControlServer(serverCtx, network.WithPort(0))
@@ -106,7 +106,7 @@ func MustSetupInsecureControlWithPool(t *testing.T, ctx context.Context, opts ..
 	return controlServer, connectionPool
 }
 
-func MustSetupSecureControlWithPool(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, *reconciler.ControlPlaneConnectionPool) {
+func MustSetupSecureControlWithPool(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, reconciler.ControlPlaneConnectionPool) {
 	serverCtx, serverCancelFn := context.WithCancel(ctx)
 
 	serverTlsConf, clientDialer := MustGenerateTestTLSConf(t, ctx)
@@ -142,8 +142,8 @@ func SendReceiveTest(t *testing.T, sender control.Service, receiver control.Serv
 	wg.Wait()
 }
 
-func ConnectionPoolTestCases() map[string]func(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, *reconciler.ControlPlaneConnectionPool) {
-	return map[string]func(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, *reconciler.ControlPlaneConnectionPool){
+func ConnectionPoolTestCases() map[string]func(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, reconciler.ControlPlaneConnectionPool) {
+	return map[string]func(t *testing.T, ctx context.Context, opts ...reconciler.ControlPlaneConnectionPoolOption) (*network.ControlServer, reconciler.ControlPlaneConnectionPool){
 		"InsecureConnectionPool": MustSetupInsecureControlWithPool,
 		"TLSConnectionPool":      MustSetupSecureControlWithPool,
 	}


### PR DESCRIPTION
The lack of interfaces on public facing structs makes unit testing code that uses this library difficult.

# Changes 

- :gift: Added interfaces to the `ControlPlaneConnectionPool` and `AsyncCommandNotificationStore` to allow for easier testing by control-protocol users.

/kind api-change
/kind enhancement

**Release Note**

```release-note
The NewInsecureControlPlaneConnectionPool() and NewControlPlaneConnectionPool() constructors now return an Interface instead of a struct pointer.  Given that all member data on the struct was package-private this should be equivalent but will require removing the `*` from types in consuming code.  The same is true for the NewAsyncCommandNotificationStore() constructor as well.
```
