### PR TITLE
Fix Failing Conformance Tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ 'main' ]
 
   schedule:
-  - cron: '0 0 * * *'
+  - cron: '0 4 * * *'
 
 defaults:
   run:
@@ -20,10 +20,6 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        #        k8s-version:
-        #        - v1.18.15
-        #        - v1.19.7
-        #        - v1.20.2
         k8s-version:
         - v1.19.11
         - v1.20.7
@@ -35,16 +31,6 @@ jobs:
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.10.0
-        #        include:
-        #        - k8s-version: v1.18.15
-        #          kind-version: v0.10.0
-        #          kind-image-sha: sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
-        #        - k8s-version: v1.19.7
-        #          kind-version: v0.10.0
-        #          kind-image-sha: sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
-        #        - k8s-version: v1.20.2
-        #          kind-version: v0.10.0
-        #          kind-image-sha: sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
         include:
         - k8s-version: v1.19.11
           kind-version: v0.11.1
@@ -151,8 +137,7 @@ jobs:
         export GOFLAGS=-mod=vendor
         export SYSTEM_NAMESPACE=default
         # Run the tests tagged as e2e on the KinD cluster.
-        # TODO - REMOVE "-v" FOR PRODUCTION !!!
-        go test -race -count=1 -parallel=12 -timeout=10m -tags=e2e -v \
+        go test -race -count=1 -parallel=12 -timeout=10m -tags=e2e \
            ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
     - name: Collect system diagnostics

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -151,7 +151,8 @@ jobs:
         export GOFLAGS=-mod=vendor
         export SYSTEM_NAMESPACE=default
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -parallel=12 -timeout=10m -tags=e2e \
+        # TODO - REMOVE "-v" FOR PRODUCTION !!!
+        go test -race -count=1 -parallel=12 -timeout=10m -tags=e2e -v \
            ${{ matrix.test-suite }} ${{ matrix.extra-test-flags }}
 
     - name: Collect system diagnostics

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -133,7 +133,7 @@ jobs:
       run: |
         set -x
 
-        kind create cluster --config kind.yaml
+        kind create cluster --config=kind.yaml
 
     - name: Upload Test Images
       run: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,10 +20,14 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
+        #        k8s-version:
+        #        - v1.18.15
+        #        - v1.19.7
+        #        - v1.20.2
         k8s-version:
-        - v1.18.15
-        - v1.19.7
-        - v1.20.2
+        - v1.19.11
+        - v1.20.7
+        - v1.21.1
 
         test-suite:
         - ./test/conformance
@@ -31,7 +35,7 @@ jobs:
         # Map between K8s and KinD versions.
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.10.0
-        include:
+        #        include:
         #        - k8s-version: v1.18.15
         #          kind-version: v0.10.0
         #          kind-image-sha: sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
@@ -41,6 +45,7 @@ jobs:
         #        - k8s-version: v1.20.2
         #          kind-version: v0.10.0
         #          kind-image-sha: sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
+        include:
         - k8s-version: v1.19.11
           kind-version: v0.11.1
           kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ 'main' ]
 
   schedule:
-  - cron: '0 */2 * * *'
+  - cron: '0 0 * * *'
 
 defaults:
   run:
@@ -32,15 +32,24 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.10.0
         include:
-        - k8s-version: v1.18.15
-          kind-version: v0.10.0
-          kind-image-sha: sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
-        - k8s-version: v1.19.7
-          kind-version: v0.10.0
-          kind-image-sha: sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
-        - k8s-version: v1.20.2
-          kind-version: v0.10.0
-          kind-image-sha: sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
+        #        - k8s-version: v1.18.15
+        #          kind-version: v0.10.0
+        #          kind-image-sha: sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
+        #        - k8s-version: v1.19.7
+        #          kind-version: v0.10.0
+        #          kind-image-sha: sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
+        #        - k8s-version: v1.20.2
+        #          kind-version: v0.10.0
+        #          kind-image-sha: sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
+        - k8s-version: v1.19.11
+          kind-version: v0.11.1
+          kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+        - k8s-version: v1.20.7
+          kind-version: v0.11.1
+          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+        - k8s-version: v1.21.1
+          kind-version: v0.11.1
+          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/conformance

--- a/test/conformance/feature/conformance_feature.go
+++ b/test/conformance/feature/conformance_feature.go
@@ -19,15 +19,11 @@ package feature
 import (
 	"context"
 	"fmt"
-	"log"
-	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
@@ -113,20 +109,9 @@ func conformanceFeature(featureName string, clientImage string, serverImage stri
 
 	}
 
-	// TODO - DEBUG ONLY - DO NOT MERGE !!!
-	f.Setup("*** DEBUG 0 *** ", func(ctx context.Context, t feature.T) {
-		log.Println(fmt.Sprintf("*** DEBUG 0 *** namespace = %s", environment.FromContext(ctx).Namespace()))
-		log.Println(fmt.Sprintf("*** DEBUG 0 *** server = %s", server))
-		log.Println(fmt.Sprintf("*** DEBUG 0 *** serverImage = %s", serverImage))
-		log.Println(fmt.Sprintf("*** DEBUG 0 *** port = %d", port))
-		log.Println(fmt.Sprintf("*** DEBUG 0 *** tls = %t", tls))
-	})
-
 	f.Setup("Start server", conformance_server.StartPod(server, serverImage, port, tls))
 	f.Setup("Wait for server ready", func(ctx context.Context, t feature.T) {
-		// TODO - DEBUG ONLY - DO NOT MERGE !!!
-		//k8s.WaitForPodRunningOrFail(ctx, t, server)
-		customWaitForPodRunningOrFail(ctx, t, server)
+		k8s.WaitForPodRunningOrFail(ctx, t, server)
 	})
 	f.Setup("Start client", func(ctx context.Context, t feature.T) {
 		pod, err := kubeclient.Get(ctx).CoreV1().Pods(environment.FromContext(ctx).Namespace()).Get(ctx, server, metav1.GetOptions{})
@@ -150,84 +135,4 @@ func conformanceFeature(featureName string, clientImage string, serverImage stri
 	})
 
 	return f
-}
-
-// TODO - DEBUG ONLY - DO NOT MERGE !!!
-func customWaitForPodRunningOrFail(ctx context.Context, t feature.T, podName string) {
-	log.Println(fmt.Sprintf("podName = %s", podName))
-	log.Println(fmt.Sprintf("namespace = %s", environment.FromContext(ctx).Namespace()))
-	podClient := kubeclient.Get(ctx).CoreV1().Pods(environment.FromContext(ctx).Namespace())
-	p := podClient
-	interval, timeout := k8s.PollTimings(ctx, nil)
-	log.Println(fmt.Sprintf("Defaults: interval = %s, timeout = %s", interval, timeout))
-	interval = 2 * time.Second
-	timeout = 3 * time.Minute
-	log.Println(fmt.Sprintf("Updated: interval = %s, timeout = %s", interval, timeout))
-	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		p, err := p.Get(ctx, podName, metav1.GetOptions{})
-		if err != nil {
-			log.Println(fmt.Sprintf("*** DEBUG 1 *** p.Get() error = %+v", err))
-			return true, err
-		}
-		return customPodRunning(p), nil // TODO - Times-Out Here Since Status.Phase Is "Pending" !
-	})
-	if err != nil {
-		log.Println(fmt.Sprintf("*** DEBUG 2 *** wait.PollImmediate() error = %+v", err))
-		sb := strings.Builder{}
-		if p, err := podClient.Get(ctx, podName, metav1.GetOptions{}); err != nil {
-			log.Println(fmt.Sprintf("*** DEBUG 3 *** podClient.Get() error = %+v", err))
-			sb.WriteString(err.Error())
-			sb.WriteString("\n")
-		} else {
-			log.Println(fmt.Sprintf("*** DEBUG 4 *** len(p.Spec.Containers) = %d, pod.Status=%s", len(p.Spec.Containers), p.Status.String()))
-			for _, c := range p.Spec.Containers {
-				log.Println(fmt.Sprintf("*** DEBUG 4.1 *** container.Name = %s, container.Image = %s", c.Name, c.Image))
-				if b, err := k8s.PodLogs(ctx, podName, c.Name, environment.FromContext(ctx).Namespace()); err != nil {
-					log.Println(fmt.Sprintf("*** DEBUG 4.2 *** k8s.PodLogs() error = %+v", err))
-					sb.WriteString(err.Error())
-				} else {
-					log.Println(fmt.Sprintf("*** DEBUG 4.2 *** k8s.PodLogs() bytes = %q", b))
-					sb.Write(b)
-				}
-				sb.WriteString("\n")
-			}
-		}
-		log.Println(fmt.Sprintf("*** DEBUG 5 *** sb = %s", sb.String()))
-		customListEvents(ctx)
-		customListNodes(ctx)
-		t.Fatalf("Failed while waiting for pod %s running: %+v", podName, errors.WithStack(err)) // TODO - Log "sb" here?
-	} else {
-		log.Println("*** DEBUG 6 *** Pod Detected As Running Or Succeeded!")
-	}
-}
-
-// TODO - DEBUG ONLY - DO NOT MERGE !!!
-func customPodRunning(pod *corev1.Pod) bool {
-	log.Println(fmt.Sprintf("*** DEBUG A *** pod.Status.Phase = %s", pod.Status.Phase))
-	return pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodSucceeded
-}
-
-// TODO - DEBUG ONLY - DO NOT MERGE !!!
-func customListEvents(ctx context.Context) {
-	eventClient := kubeclient.Get(ctx).CoreV1().Events(environment.FromContext(ctx).Namespace())
-	events, err := eventClient.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		log.Println(fmt.Sprintf("*** DEBUG B *** Failed to list events err = %+v", err))
-		return
-	}
-	for _, event := range events.Items {
-		log.Println(fmt.Sprintf("*** DEBUG B *** event = %s", event.String()))
-	}
-}
-
-// TODO - DEBUG ONLY - DO NOT MERGE !!!
-func customListNodes(ctx context.Context) {
-	nodes, err := kubeclient.Get(ctx).CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		log.Println(fmt.Sprintf("*** DEBUG C *** Failed to list nodes err = %+v", err))
-		return
-	}
-	for _, node := range nodes.Items {
-		log.Println(fmt.Sprintf("*** DEBUG C *** node = %s", node.String()))
-	}
 }

--- a/test/conformance/feature/conformance_feature.go
+++ b/test/conformance/feature/conformance_feature.go
@@ -194,6 +194,7 @@ func customWaitForPodRunningOrFail(ctx context.Context, t feature.T, podName str
 		}
 		log.Println(fmt.Sprintf("*** DEBUG 5 *** sb = %s", sb.String()))
 		customListEvents(ctx)
+		customListNodes(ctx)
 		t.Fatalf("Failed while waiting for pod %s running: %+v", podName, errors.WithStack(err)) // TODO - Log "sb" here?
 	} else {
 		log.Println("*** DEBUG 6 *** Pod Detected As Running Or Succeeded!")
@@ -214,8 +215,19 @@ func customListEvents(ctx context.Context) {
 		log.Println(fmt.Sprintf("*** DEBUG B *** Failed to list events err = %+v", err))
 		return
 	}
-
 	for _, event := range events.Items {
 		log.Println(fmt.Sprintf("*** DEBUG B *** event = %s", event.String()))
+	}
+}
+
+// TODO - DEBUG ONLY - DO NOT MERGE !!!
+func customListNodes(ctx context.Context) {
+	nodes, err := kubeclient.Get(ctx).CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Println(fmt.Sprintf("*** DEBUG C *** Failed to list nodes err = %+v", err))
+		return
+	}
+	for _, node := range nodes.Items {
+		log.Println(fmt.Sprintf("*** DEBUG C *** node = %s", node.String()))
 	}
 }


### PR DESCRIPTION
The conformance tests (kind-e2e) have been failing for a long time now - this fixes them.

The tests run fine locally but fail in Git PRs.  The "server" pod was never able to become READY because the "worker" node in the KinD cluster had a "not-ready" taint.  The root cause for this was not determined, but upgrading the KinD version, as well as the three tested K8S versions resolved the problem.

## Proposed Changes
- 🧽  Change the kind-e2e schedule from once every 2 hours to once daily.
- 🧽  Increment KinD version from v0.10.0 to v0.11.1
- 🧽  Increment the tested K8S versions from 18,19,20 to 29,20,21
