### PR TITLE
bump k8s and kind versions in e2e test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.19.11
-        - v1.20.7
-        - v1.21.1
+        - v1.22.9
+        - v1.23.6
+        - v1.24.0
 
         test-suite:
         - ./test/conformance
@@ -29,15 +29,15 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.10.0
         include:
-        - k8s-version: v1.19.11
-          kind-version: v0.11.1
-          kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
-        - k8s-version: v1.20.7
-          kind-version: v0.11.1
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-        - k8s-version: v1.21.1
-          kind-version: v0.11.1
-          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - k8s-version: v1.22.9
+          kind-version: v0.14.0
+          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+        - k8s-version: v1.23.6
+          kind-version: v0.14.0
+          kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+        - k8s-version: v1.24.0
+          kind-version: v0.14.0
+          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
 
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/conformance


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Since we will probably be supporting Kubernetes v1.24 in the next release, and kind v0.13.0+ is required to run Kubernetes v1.24.0+ images, let's go ahead and bump the versions now, so we have a chance to work out any issues before the next release.