### PR TITLE
store certs under different names in secrets

### DIFF
--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -20,6 +20,13 @@ const (
 	Organization = "knative.dev"
 	FakeDnsName  = "data-plane." + Organization
 
+	//These keys are meant to line up with cert-manager, see
+	//https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats
+	CaCertName     = "ca.crt"
+	CertName       = "tls.crt"
+	PrivateKeyName = "tls.key"
+
+	//These should be able to be deprecated some time in the future when the new names are fully adopted
 	SecretCaCertKey = "ca-cert.pem"
 	SecretCertKey   = "public-cert.pem"
 	SecretPKKey     = "private-key.pem"

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -163,10 +163,13 @@ func (r *reconciler) commitUpdatedSecret(ctx context.Context, secret *corev1.Sec
 	secret = secret.DeepCopy()
 
 	secret.Data = make(map[string][]byte, 3)
+	secret.Data[certificates.CertName] = keyPair.CertBytes()
+	secret.Data[certificates.PrivateKeyName] = keyPair.PrivateKeyBytes()
 	secret.Data[certificates.SecretCertKey] = keyPair.CertBytes()
 	secret.Data[certificates.SecretPKKey] = keyPair.PrivateKeyBytes()
 	if caCert != nil {
 		secret.Data[certificates.SecretCaCertKey] = caCert
+		secret.Data[certificates.CaCertName] = caCert
 	}
 
 	_, err := r.client.CoreV1().Secrets(secret.Namespace).Update(ctx, secret, metav1.UpdateOptions{})

--- a/pkg/certificates/reconciler/certificates_test.go
+++ b/pkg/certificates/reconciler/certificates_test.go
@@ -72,8 +72,10 @@ func TestReconcile(t *testing.T) {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			certificates.SecretCertKey: caKP.CertBytes(),
-			certificates.SecretPKKey:   caKP.PrivateKeyBytes(),
+			certificates.SecretCertKey:  caKP.CertBytes(),
+			certificates.SecretPKKey:    caKP.PrivateKeyBytes(),
+			certificates.CertName:       caKP.CertBytes(),
+			certificates.PrivateKeyName: caKP.PrivateKeyBytes(),
 		},
 	}
 
@@ -91,6 +93,9 @@ func TestReconcile(t *testing.T) {
 			certificates.SecretCaCertKey: caKP.CertBytes(),
 			certificates.SecretCertKey:   controlPlaneKP.CertBytes(),
 			certificates.SecretPKKey:     controlPlaneKP.PrivateKeyBytes(),
+			certificates.CaCertName:      caKP.CertBytes(),
+			certificates.CertName:        controlPlaneKP.CertBytes(),
+			certificates.PrivateKeyName:  controlPlaneKP.PrivateKeyBytes(),
 		},
 	}
 
@@ -108,6 +113,9 @@ func TestReconcile(t *testing.T) {
 			certificates.SecretCaCertKey: caKP.CertBytes(),
 			certificates.SecretCertKey:   dataPlaneKP.CertBytes(),
 			certificates.SecretPKKey:     dataPlaneKP.PrivateKeyBytes(),
+			certificates.CaCertName:      caKP.CertBytes(),
+			certificates.CertName:        controlPlaneKP.CertBytes(),
+			certificates.PrivateKeyName:  controlPlaneKP.PrivateKeyBytes(),
 		},
 	}
 
@@ -315,16 +323,26 @@ func mustCreateControlPlaneCert(t *testing.T, expirationInterval time.Duration, 
 }
 
 func validCACert(t *testing.T, secret *corev1.Secret) {
-	require.Contains(t, secret.Data, certificates.SecretPKKey)
-	require.Contains(t, secret.Data, certificates.SecretCertKey)
-	cert, pk, err := certificates.ParseCert(secret.Data[certificates.SecretCertKey], secret.Data[certificates.SecretPKKey])
+	require.Contains(t, secret.Data, certificates.PrivateKeyName)
+	require.Contains(t, secret.Data, certificates.CertName)
+	cert, pk, err := certificates.ParseCert(secret.Data[certificates.CertName], secret.Data[certificates.PrivateKeyName])
 	require.NotNil(t, cert)
 	require.NotNil(t, pk)
 	require.NoError(t, err)
+
+	require.Contains(t, secret.Data, certificates.SecretPKKey)
+	require.Contains(t, secret.Data, certificates.SecretCertKey)
+	cert, pk, err = certificates.ParseCert(secret.Data[certificates.SecretCertKey], secret.Data[certificates.SecretPKKey])
+	require.NotNil(t, cert)
+	require.NotNil(t, pk)
+	require.NoError(t, err)
+
 }
 
 func validDataPlaneCert(t *testing.T, secret *corev1.Secret) {
+	require.Contains(t, secret.Data, certificates.CaCertName)
 	require.Contains(t, secret.Data, certificates.SecretCaCertKey)
+
 	validCACert(t, secret)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: update current behavior, in support of https://github.com/knative-sandbox/net-contour/pull/819
- Contour requires CA data to be stored under the name `ca.crt` in a secret
- This also is in line with how [certmanager names cert data in secrets](https://cert-manager.io/docs/usage/certificate/\#additional-certificate-output-formats)
- leave the old names around for a while in case other components depend on this naming.
- Discussion about this in [Knative Slack](https://knative.slack.com/archives/CA4DNJ9A4/p1665503042270749)
- I plan to use these changes in serving, where I can set the secret type to TLS: https://github.com/knative/serving/pull/13388


/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
N/A
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
