### PR TITLE
bump k8s versions used by e2e

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.9
-        - v1.23.6
-        - v1.24.0
+        - v1.23.12
+        - v1.24.6
+        - v1.25.2
 
         test-suite:
         - ./test/conformance
@@ -28,16 +28,17 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.10.0
         include:
-        - k8s-version: v1.22.9
-          kind-version: v0.14.0
-          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
-        - k8s-version: v1.23.6
-          kind-version: v0.14.0
-          kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
-        - k8s-version: v1.24.0
-          kind-version: v0.14.0
-          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+        - k8s-version: v1.23.12
+          kind-version: v0.16.0
+          kind-image-sha: sha256:934835129873881bbfac668e1da74890c749afed16e020cd173b77788841155c
 
+        - k8s-version: v1.24.6
+          kind-version: v0.16.0
+          kind-image-sha: sha256:ec13a9319ee30ab5e842517a9dffdb8e3c0e36151ffdef82b41be537ac124fbc
+
+        - k8s-version: v1.25.2
+          kind-version: v0.16.0
+          kind-image-sha: sha256:6e0f9005eba4010e364aa1bb25c8d7c64f050f744258eb68c4eb40c284c3c0dd
         # Add the flags we use for each of these test suites.
         - test-suite: ./test/conformance
           extra-test-flags: ""


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- align with other knative repos
- remove 1.22.x
- add 1.25.x

