### PR TITLE
Upgrade to new reconciler-test@release-1.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/client-go v0.25.4
 	knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9
 	knative.dev/pkg v0.0.0-20230117181655-247510c00e9d
-	knative.dev/reconciler-test v0.0.0-20230117204655-f83270bba2ac
+	knative.dev/reconciler-test v0.0.0-20230120192401-894bc7013c23
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -893,8 +893,8 @@ knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9 h1:CDa7s9KspEZqPhk7cN68ZypRL
 knative.dev/hack v0.0.0-20230113013652-c7cfcb062de9/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/pkg v0.0.0-20230117181655-247510c00e9d h1:pjKDcvHoMib8nRp56eISRmMj/pFMzJljnzvMvGCIReI=
 knative.dev/pkg v0.0.0-20230117181655-247510c00e9d/go.mod h1:VO/fcEsq43seuONRQxZyftWHjpMabYzRHDtpSEQ/eoQ=
-knative.dev/reconciler-test v0.0.0-20230117204655-f83270bba2ac h1:ClV9PPAo2Da/nSw/2VNVEmXteTALnNrTiXVYzNLCi+Q=
-knative.dev/reconciler-test v0.0.0-20230117204655-f83270bba2ac/go.mod h1:ZPUBldkrSIOe0c57sDcnuM4bzQy16iTtvMV59nMPpfs=
+knative.dev/reconciler-test v0.0.0-20230120192401-894bc7013c23 h1:Lrq9tVIhudcu+hux2hkUxKjgT1gnlekPii0xGkylSjM=
+knative.dev/reconciler-test v0.0.0-20230120192401-894bc7013c23/go.mod h1:ZPUBldkrSIOe0c57sDcnuM4bzQy16iTtvMV59nMPpfs=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/vendor/knative.dev/reconciler-test/pkg/environment/logging.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/logging.go
@@ -20,12 +20,16 @@ import (
 	"context"
 
 	"go.uber.org/zap/zaptest"
+
 	"knative.dev/reconciler-test/pkg/feature"
 	testlog "knative.dev/reconciler-test/pkg/logging"
 )
 
 // loggingSteps returns a number of steps that logs environment-managed resources.
 func (mr *MagicEnvironment) loggingSteps() []feature.Step {
+	mr.refsMu.Lock()
+	defer mr.refsMu.Unlock()
+
 	return []feature.Step{{
 		Name: "Log references",
 		S:    feature.Any,

--- a/vendor/knative.dev/reconciler-test/pkg/environment/magic.go
+++ b/vendor/knative.dev/reconciler-test/pkg/environment/magic.go
@@ -70,6 +70,7 @@ type MagicEnvironment struct {
 	namespace        string
 	namespaceCreated bool
 	refs             []corev1.ObjectReference
+	refsMu           sync.Mutex
 
 	// milestones sends milestone events, if configured.
 	milestones milestone.Emitter
@@ -87,11 +88,19 @@ const (
 )
 
 func (mr *MagicEnvironment) Reference(ref ...corev1.ObjectReference) {
+	mr.refsMu.Lock()
+	defer mr.refsMu.Unlock()
+
 	mr.refs = append(mr.refs, ref...)
 }
 
 func (mr *MagicEnvironment) References() []corev1.ObjectReference {
-	return mr.refs
+	mr.refsMu.Lock()
+	defer mr.refsMu.Unlock()
+
+	r := make([]corev1.ObjectReference, len(mr.refs))
+	copy(r, mr.refs)
+	return r
 }
 
 func (mr *MagicEnvironment) Finish() {
@@ -216,7 +225,9 @@ func (mr *MagicEnvironment) TemplateConfig(base map[string]interface{}) map[stri
 	for k, v := range base {
 		cfg[k] = v
 	}
-	cfg["namespace"] = mr.namespace
+	if _, ok := cfg["namespace"]; !ok {
+		cfg["namespace"] = mr.namespace
+	}
 	return cfg
 }
 

--- a/vendor/knative.dev/reconciler-test/pkg/k8s/wait.go
+++ b/vendor/knative.dev/reconciler-test/pkg/k8s/wait.go
@@ -37,6 +37,7 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/kmeta"
+
 	"knative.dev/reconciler-test/pkg/environment"
 	"knative.dev/reconciler-test/pkg/feature"
 )
@@ -251,6 +252,11 @@ func WaitForServiceEndpoints(ctx context.Context, t feature.T, name string, numb
 	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		svc, err := services.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Log("service", "namespace", ns, "name", name, err)
+				// keep polling
+				return false, nil
+			}
 			return false, err
 		}
 		ip := svc.Spec.ClusterIP
@@ -374,6 +380,11 @@ func WaitForPodRunningOrFail(ctx context.Context, t feature.T, podName string) {
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		p, err := p.Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Log("pod", "namespace", ns, "name", podName, err)
+				// keep polling
+				return false, nil
+			}
 			return true, err
 		}
 		isRunning := podRunning(p)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1109,7 +1109,7 @@ knative.dev/pkg/test/security
 knative.dev/pkg/test/zipkin
 knative.dev/pkg/tracing/config
 knative.dev/pkg/tracker
-# knative.dev/reconciler-test v0.0.0-20230117204655-f83270bba2ac
+# knative.dev/reconciler-test v0.0.0-20230120192401-894bc7013c23
 ## explicit; go 1.18
 knative.dev/reconciler-test/pkg/environment
 knative.dev/reconciler-test/pkg/feature


### PR DESCRIPTION
/assign @gab-satchi @pierDipi 

# Changes

- The `reconciler-test` package had 6 changes merged to the `release-1.9` branch. This PR merges in those changes, so `control-protocol@release-1.9` matches the latest `reconciler-test` release, in preparation for next week's 1.9 release cut.

/kind cleanup