### PR TITLE
Support Ctrl, Data-Routing and Data-User certificates

### DIFF
--- a/pkg/certificates/certs.go
+++ b/pkg/certificates/certs.go
@@ -32,8 +32,6 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-var TID uint32 = 0
-
 var randReader = rand.Reader
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 

--- a/pkg/certificates/certs.go
+++ b/pkg/certificates/certs.go
@@ -35,7 +35,7 @@ import (
 var randReader = rand.Reader
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
-// Copy-pasted from https://github.com/knative/pkg/blob/975a1cf9e4470b26ce54d9cc628dbd50716b6b95/webhook/certificates/resources/certs.go
+// Create template common to all certificates
 func createCertTemplate(expirationInterval time.Duration, sans []string) (*x509.Certificate, error) {
 	serialNumber, err := rand.Int(randReader, serialNumberLimit)
 	if err != nil {

--- a/pkg/certificates/certs.go
+++ b/pkg/certificates/certs.go
@@ -37,7 +37,6 @@ var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
 // Copy-pasted from https://github.com/knative/pkg/blob/975a1cf9e4470b26ce54d9cc628dbd50716b6b95/webhook/certificates/resources/certs.go
 func createCertTemplate(expirationInterval time.Duration, sans []string) (*x509.Certificate, error) {
-
 	serialNumber, err := rand.Int(randReader, serialNumberLimit)
 	if err != nil {
 		return nil, errors.New("failed to generate serial number: " + err.Error())
@@ -62,17 +61,15 @@ func createCACertTemplate(expirationInterval time.Duration) (*x509.Certificate, 
 	}
 	// Make it into a CA cert and change it so we can use it to sign certs
 	rootCert.IsCA = true
-	rootCert.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
-	rootCert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	rootCert.KeyUsage = x509.KeyUsageCertSign
 	rootCert.Subject = pkix.Name{
 		Organization: []string{Organization},
-		CommonName:   "control-plane",
 	}
 	return rootCert, nil
 }
 
 // Create cert template that we can use on the client/server for TLS
-func createClientServerCertTemplate(expirationInterval time.Duration, sans []string) (*x509.Certificate, error) {
+func createTransportCertTemplate(expirationInterval time.Duration, sans []string) (*x509.Certificate, error) {
 	cert, err := createCertTemplate(expirationInterval, sans)
 	if err != nil {
 		return nil, err
@@ -81,8 +78,7 @@ func createClientServerCertTemplate(expirationInterval time.Duration, sans []str
 	cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
 	cert.Subject = pkix.Name{
 		Organization: []string{Organization},
-		// Do not use the same value with CA.
-		CommonName: "control-protocol-certificate",
+		CommonName:   "control-protocol-certificate",
 	}
 	return cert, err
 }
@@ -147,7 +143,7 @@ func CreateCert(ctx context.Context, caKey *rsa.PrivateKey, caCertificate *x509.
 		return nil, err
 	}
 
-	certTemplate, err := createClientServerCertTemplate(expirationInterval, sans)
+	certTemplate, err := createTransportCertTemplate(expirationInterval, sans)
 	if err != nil {
 		logger.Errorw("failed to create the certificate template", zap.Error(err))
 		return nil, err
@@ -156,7 +152,7 @@ func CreateCert(ctx context.Context, caKey *rsa.PrivateKey, caCertificate *x509.
 	// create a certificate which wraps the public key, sign it with the CA private key
 	_, certPEM, err := createCert(certTemplate, caCertificate, &keyPair.PublicKey, caKey)
 	if err != nil {
-		logger.Errorw("error signing server certificate template", zap.Error(err))
+		logger.Errorw("error signing certificate template", zap.Error(err))
 		return nil, err
 	}
 

--- a/pkg/certificates/certs.go
+++ b/pkg/certificates/certs.go
@@ -32,6 +32,8 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+var TID uint32 = 0
+
 var randReader = rand.Reader
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
@@ -122,12 +124,12 @@ func CreateCACerts(ctx context.Context, expirationInterval time.Duration) (*KeyP
 	return NewKeyPair(caPrivateKeyPem, caCertPem), nil
 }
 
-// CreateControlPlaneCert generates the certificate for the client
+// Deprecated - CreateControlPlaneCert generates the certificate for the client
 func CreateControlPlaneCert(ctx context.Context, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, expirationInterval time.Duration) (*KeyPair, error) {
 	return CreateCert(ctx, caKey, caCertificate, expirationInterval, LegacyFakeDnsName)
 }
 
-// CreateDataPlaneCert generates the certificate for the server
+// Deprecated - CreateDataPlaneCert generates the certificate for the server
 func CreateDataPlaneCert(ctx context.Context, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, expirationInterval time.Duration) (*KeyPair, error) {
 	return CreateCert(ctx, caKey, caCertificate, expirationInterval, LegacyFakeDnsName)
 }

--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -16,13 +16,15 @@ limitations under the License.
 
 package certificates
 
+import "strings"
+
 const (
 	Organization           = "knative.dev"
 	LegacyFakeDnsName      = "data-plane." + Organization
 	FakeDnsName            = LegacyFakeDnsName // Deprecated
-	dataPlaneUserPrefix    = "k-"
-	dataPlaneRoutingPrefix = "krouting-"
-	ControlPlaneName       = "kcontrol"
+	dataPlaneUserPrefix    = "kn-user-"
+	dataPlaneRoutingPrefix = "kn-routing-"
+	ControlPlaneName       = "kn-control"
 
 	//These keys are meant to line up with cert-manager, see
 	//https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats
@@ -42,11 +44,11 @@ func DataPlaneRoutingName(routingId string) string {
 	if routingId == "" {
 		routingId = "0"
 	}
-	return dataPlaneRoutingPrefix + routingId
+	return dataPlaneRoutingPrefix + strings.ToLower(routingId)
 }
 
 // DataPlaneUserName constructs a san for a data-plane-user certificate
 // Accepts a namespace  - the namespace for which the certificate was created
 func DataPlaneUserName(namespace string) string {
-	return dataPlaneUserPrefix + namespace
+	return dataPlaneUserPrefix + strings.ToLower(namespace)
 }

--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -20,7 +20,7 @@ const (
 	Organization           = "knative.dev"
 	LegacyFakeDnsName      = "data-plane." + Organization
 	FakeDnsName            = LegacyFakeDnsName // Deprecated
-	dataPlaneEdgePrefix    = "k-"
+	dataPlaneUserPrefix    = "k-"
 	dataPlaneRoutingPrefix = "krouting-"
 	ControlPlaneName       = "kcontrol"
 
@@ -45,8 +45,8 @@ func DataPlaneRoutingName(routingId string) string {
 	return dataPlaneRoutingPrefix + routingId
 }
 
-// DataPlaneEdgeName constructs a san for a data-plane-edge certificate
+// DataPlaneUserName constructs a san for a data-plane-user certificate
 // Accepts a namespace  - the namespace for which the certificate was created
-func DataPlaneEdgeName(namespace string) string {
-	return dataPlaneEdgePrefix + namespace
+func DataPlaneUserName(namespace string) string {
+	return dataPlaneUserPrefix + namespace
 }

--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -36,13 +36,17 @@ const (
 	SecretPKKey     = "private-key.pem"
 )
 
-func DataPlaneRoutingName(rountingId string) string {
-	if rountingId == "" {
-		rountingId = "0"
+// DataPlaneRoutingName constructs a san for a data-plane-routing certificate
+// Accepts a routingId  - a unique identifier used as part of the san (default is "0" used when an empty routingId is provided)
+func DataPlaneRoutingName(routingId string) string {
+	if routingId == "" {
+		routingId = "0"
 	}
-	return dataPlaneRoutingPrefix + rountingId
+	return dataPlaneRoutingPrefix + routingId
 }
 
+// DataPlaneEdgeName constructs a san for a data-plane-edge certificate
+// Accepts a namespace  - the namespace for which the certificate was created
 func DataPlaneEdgeName(namespace string) string {
 	return dataPlaneEdgePrefix + namespace
 }

--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -17,11 +17,12 @@ limitations under the License.
 package certificates
 
 const (
-	Organization        = "knative.dev"
-	LegacyFakeDnsName   = "data-plane." + Organization
-	FakeDnsName         = LegacyFakeDnsName
-	DataPlaneNamePrefix = "knative-"
-	ControlPlaneName    = "kcontrol"
+	Organization            = "knative.dev"
+	LegacyFakeDnsName       = "data-plane." + Organization
+	FakeDnsName             = LegacyFakeDnsName // Deprecated
+	DataPlaneEdgePrefix     = "k-"
+	DataPlanePipelinePrefix = "kpipeline-"
+	ControlPlaneName        = "kcontrol"
 
 	//These keys are meant to line up with cert-manager, see
 	//https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats

--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -21,6 +21,7 @@ const (
 	LegacyFakeDnsName   = "data-plane." + Organization
 	FakeDnsName         = LegacyFakeDnsName
 	DataPlaneNamePrefix = "knative-"
+	ControlPlaneName    = "kcontrol"
 
 	//These keys are meant to line up with cert-manager, see
 	//https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats

--- a/pkg/certificates/constants.go
+++ b/pkg/certificates/constants.go
@@ -17,12 +17,12 @@ limitations under the License.
 package certificates
 
 const (
-	Organization            = "knative.dev"
-	LegacyFakeDnsName       = "data-plane." + Organization
-	FakeDnsName             = LegacyFakeDnsName // Deprecated
-	DataPlaneEdgePrefix     = "k-"
-	DataPlanePipelinePrefix = "kpipeline-"
-	ControlPlaneName        = "kcontrol"
+	Organization           = "knative.dev"
+	LegacyFakeDnsName      = "data-plane." + Organization
+	FakeDnsName            = LegacyFakeDnsName // Deprecated
+	dataPlaneEdgePrefix    = "k-"
+	dataPlaneRoutingPrefix = "krouting-"
+	ControlPlaneName       = "kcontrol"
 
 	//These keys are meant to line up with cert-manager, see
 	//https://cert-manager.io/docs/usage/certificate/#additional-certificate-output-formats
@@ -35,3 +35,14 @@ const (
 	SecretCertKey   = "public-cert.pem"
 	SecretPKKey     = "private-key.pem"
 )
+
+func DataPlaneRoutingName(rountingId string) string {
+	if rountingId == "" {
+		rountingId = "0"
+	}
+	return dataPlaneRoutingPrefix + rountingId
+}
+
+func DataPlaneEdgeName(namespace string) string {
+	return dataPlaneEdgePrefix + namespace
+}

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	strings "strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -168,11 +169,11 @@ func parseAndValidateSecret(secret *corev1.Secret, shouldContainCaCert bool, san
 OUTER:
 	for _, san := range sans {
 		for _, certSan := range cert.DNSNames {
-			if certSan == san {
+			if strings.EqualFold(certSan, san) {
 				continue OUTER
 			}
 		}
-		return nil, nil, fmt.Errorf("missing san %s", san)
+		return nil, nil, fmt.Errorf("missing san %q", san)
 	}
 
 	return cert, caPk, nil

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -111,6 +111,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 		if !ok {
 			pipelineId = "0"
 		}
+
 		var sans []string
 		switch secret.Labels[r.secretTypeLabelName] {
 		case controlPlaneSecretType:
@@ -124,6 +125,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 		default:
 			return fmt.Errorf("unknown cert type: %v", r.secretTypeLabelName)
 		}
+
 		var keyPair *certificates.KeyPair
 		keyPair, err = certificates.CreateCert(ctx, caPk, caCert, expirationInterval, sans...)
 		if err != nil {

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -105,7 +105,7 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 	var sans []string
 	switch secret.Labels[r.secretTypeLabelName] {
 	case controlPlaneSecretType:
-		sans = []string{certificates.ControlPlaneName}
+		sans = []string{certificates.ControlPlaneName, certificates.LegacyFakeDnsName}
 	case dataPlaneRoutingSecretType:
 		routingId := secret.Labels[secretRoutingId]
 		san := certificates.DataPlaneRoutingName(routingId)

--- a/pkg/certificates/reconciler/certificates.go
+++ b/pkg/certificates/reconciler/certificates.go
@@ -48,8 +48,8 @@ const (
 	// certificates used by trusted data routing elements such as activator, ingress gw
 	dataPlaneRoutingSecretType = "data-plane-routing"
 
-	// certificates used by edges acting as senders and receivers in the data-plane such as queue
-	dataPlaneEdgeSecretType = "data-plane-edge"
+	// certificates used by entities acting as senders and receivers (users) of the data-plane such as queue
+	dataPlaneUserSecretType = "data-plane-user"
 
 	// Deprecated used by any data plane element
 	dataPlaneDeprecatedSecretType = "data-plane"
@@ -110,8 +110,8 @@ func (r *reconciler) ReconcileKind(ctx context.Context, secret *corev1.Secret) p
 		routingId := secret.Labels[secretRoutingId]
 		san := certificates.DataPlaneRoutingName(routingId)
 		sans = []string{san, certificates.LegacyFakeDnsName}
-	case dataPlaneEdgeSecretType:
-		sans = []string{certificates.DataPlaneEdgeName(secret.Namespace), certificates.LegacyFakeDnsName}
+	case dataPlaneUserSecretType:
+		sans = []string{certificates.DataPlaneUserName(secret.Namespace), certificates.LegacyFakeDnsName}
 	case dataPlaneDeprecatedSecretType:
 		sans = []string{certificates.LegacyFakeDnsName}
 	default:

--- a/pkg/certificates/reconciler/certificates_test.go
+++ b/pkg/certificates/reconciler/certificates_test.go
@@ -103,20 +103,20 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	dataPlaneEdgeKP := mustCreateDataPlaneEdgeCert(t, 10*time.Hour, caKey, caCertificate, "myns")
+	dataPlaneUserKP := mustCreateDataPlaneUserCert(t, 10*time.Hour, caKey, caCertificate, "myns")
 
-	wellFormedDataPlaneEdgeSecret := &corev1.Secret{
+	wellFormedDataPlaneUserSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "data-plane-edge-ctrl",
+			Name:      "data-plane-user-ctrl",
 			Namespace: namespace,
 			Labels: map[string]string{
-				labelName: dataPlaneEdgeSecretType,
+				labelName: dataPlaneUserSecretType,
 			},
 		},
 		Data: map[string][]byte{
 			certificates.SecretCaCertKey: caKP.CertBytes(),
-			certificates.SecretCertKey:   dataPlaneEdgeKP.CertBytes(),
-			certificates.SecretPKKey:     dataPlaneEdgeKP.PrivateKeyBytes(),
+			certificates.SecretCertKey:   dataPlaneUserKP.CertBytes(),
+			certificates.SecretPKKey:     dataPlaneUserKP.PrivateKeyBytes(),
 			certificates.CaCertName:      caKP.CertBytes(),
 			certificates.CertName:        controlPlaneKP.CertBytes(),
 			certificates.PrivateKeyName:  controlPlaneKP.PrivateKeyBytes(),
@@ -162,15 +162,15 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "well formed secret CA and data plane edge secret exists",
+		name:    "well formed secret CA and data plane user secret exists",
 		key:     namespace + "/data-plane-ctrl",
-		objects: []*corev1.Secret{wellFormedCaSecret, wellFormedDataPlaneEdgeSecret},
+		objects: []*corev1.Secret{wellFormedCaSecret, wellFormedDataPlaneUserSecret},
 		asserts: map[string]func(*testing.T, *corev1.Secret){
 			wellFormedCaSecret.Name: func(t *testing.T, secret *corev1.Secret) {
 				require.Equal(t, wellFormedCaSecret, secret)
 			},
-			wellFormedDataPlaneEdgeSecret.Name: func(t *testing.T, secret *corev1.Secret) {
-				require.Equal(t, wellFormedDataPlaneEdgeSecret, secret)
+			wellFormedDataPlaneUserSecret.Name: func(t *testing.T, secret *corev1.Secret) {
+				require.Equal(t, wellFormedDataPlaneUserSecret, secret)
 			},
 		},
 	}, {
@@ -208,7 +208,7 @@ func TestReconcile(t *testing.T) {
 			"control-plane-ctrl": validControlPlaneCert,
 		},
 	}, {
-		name:                   "empty CA secret and empty data plane edge secret",
+		name:                   "empty CA secret and empty data plane user secret",
 		key:                    namespace + "/data-plane-ctrl",
 		executeReconcilerTwice: true,
 		objects: []*corev1.Secret{{
@@ -221,7 +221,7 @@ func TestReconcile(t *testing.T) {
 				Name:      "data-plane-ctrl",
 				Namespace: namespace,
 				Labels: map[string]string{
-					labelName: dataPlaneEdgeSecretType,
+					labelName: dataPlaneUserSecretType,
 				},
 			},
 		}},
@@ -368,8 +368,8 @@ func mustCreateCACert(t *testing.T, expirationInterval time.Duration) (*certific
 	return kp, cert, pk
 }
 
-func mustCreateDataPlaneEdgeCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, namespace string) *certificates.KeyPair {
-	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneEdgeName(namespace), certificates.LegacyFakeDnsName)
+func mustCreateDataPlaneUserCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, namespace string) *certificates.KeyPair {
+	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneUserName(namespace), certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 	return kp
 }

--- a/pkg/certificates/reconciler/certificates_test.go
+++ b/pkg/certificates/reconciler/certificates_test.go
@@ -83,7 +83,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	controlPlaneKP := mustCreateControlPlaneCert(t, 10*time.Hour, caKey, caCertificate, "myns")
+	controlPlaneKP := mustCreateControlPlaneCert(t, 10*time.Hour, caKey, caCertificate)
 
 	wellFormedControlPlaneSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -123,7 +123,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	dataPlanePipelineKP := mustCreateDataPlanePipelineCert(t, 10*time.Hour, caKey, caCertificate, "myns")
+	dataPlanePipelineKP := mustCreateDataPlanePipelineCert(t, 10*time.Hour, caKey, caCertificate, "0")
 
 	wellFormedDataPlanePipelineSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -374,14 +374,14 @@ func mustCreateDataPlaneEdgeCert(t *testing.T, expirationInterval time.Duration,
 	return kp
 }
 
-func mustCreateDataPlanePipelineCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, namespace string) *certificates.KeyPair {
-	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneEdgePrefix+namespace, certificates.LegacyFakeDnsName)
+func mustCreateDataPlanePipelineCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, pipelineId string) *certificates.KeyPair {
+	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlanePipelinePrefix+pipelineId, certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 	return kp
 }
 
-func mustCreateControlPlaneCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, namespace string) *certificates.KeyPair {
-	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneEdgePrefix+namespace, certificates.LegacyFakeDnsName)
+func mustCreateControlPlaneCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate) *certificates.KeyPair {
+	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.ControlPlaneName)
 	require.NoError(t, err)
 	return kp
 }

--- a/pkg/certificates/reconciler/certificates_test.go
+++ b/pkg/certificates/reconciler/certificates_test.go
@@ -123,20 +123,20 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	dataPlanePipelineKP := mustCreateDataPlanePipelineCert(t, 10*time.Hour, caKey, caCertificate, "0")
+	dataPlaneRoutingKP := mustCreateDataPlaneRoutingCert(t, 10*time.Hour, caKey, caCertificate, "0")
 
-	wellFormedDataPlanePipelineSecret := &corev1.Secret{
+	wellFormedDataPlaneRoutingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "data-plane-pipeline-ctrl",
+			Name:      "data-plane-routing-ctrl",
 			Namespace: namespace,
 			Labels: map[string]string{
-				labelName: dataPlanePipelineSecretType,
+				labelName: dataPlaneRoutingSecretType,
 			},
 		},
 		Data: map[string][]byte{
 			certificates.SecretCaCertKey: caKP.CertBytes(),
-			certificates.SecretCertKey:   dataPlanePipelineKP.CertBytes(),
-			certificates.SecretPKKey:     dataPlanePipelineKP.PrivateKeyBytes(),
+			certificates.SecretCertKey:   dataPlaneRoutingKP.CertBytes(),
+			certificates.SecretPKKey:     dataPlaneRoutingKP.PrivateKeyBytes(),
 			certificates.CaCertName:      caKP.CertBytes(),
 			certificates.CertName:        controlPlaneKP.CertBytes(),
 			certificates.PrivateKeyName:  controlPlaneKP.PrivateKeyBytes(),
@@ -174,15 +174,15 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "well formed secret CA and data plane pipeline secret exists",
+		name:    "well formed secret CA and data plane routing secret exists",
 		key:     namespace + "/data-plane-ctrl",
-		objects: []*corev1.Secret{wellFormedCaSecret, wellFormedDataPlanePipelineSecret},
+		objects: []*corev1.Secret{wellFormedCaSecret, wellFormedDataPlaneRoutingSecret},
 		asserts: map[string]func(*testing.T, *corev1.Secret){
 			wellFormedCaSecret.Name: func(t *testing.T, secret *corev1.Secret) {
 				require.Equal(t, wellFormedCaSecret, secret)
 			},
-			wellFormedDataPlanePipelineSecret.Name: func(t *testing.T, secret *corev1.Secret) {
-				require.Equal(t, wellFormedDataPlanePipelineSecret, secret)
+			wellFormedDataPlaneRoutingSecret.Name: func(t *testing.T, secret *corev1.Secret) {
+				require.Equal(t, wellFormedDataPlaneRoutingSecret, secret)
 			},
 		},
 	}, {
@@ -230,7 +230,7 @@ func TestReconcile(t *testing.T) {
 			"data-plane-ctrl": validControlPlaneCert,
 		},
 	}, {
-		name:                   "empty CA secret and empty data plane pipeline secret",
+		name:                   "empty CA secret and empty data plane routing secret",
 		key:                    namespace + "/data-plane-ctrl",
 		executeReconcilerTwice: true,
 		objects: []*corev1.Secret{{
@@ -243,7 +243,7 @@ func TestReconcile(t *testing.T) {
 				Name:      "data-plane-ctrl",
 				Namespace: namespace,
 				Labels: map[string]string{
-					labelName: dataPlanePipelineSecretType,
+					labelName: dataPlaneRoutingSecretType,
 				},
 			},
 		}},
@@ -369,13 +369,13 @@ func mustCreateCACert(t *testing.T, expirationInterval time.Duration) (*certific
 }
 
 func mustCreateDataPlaneEdgeCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, namespace string) *certificates.KeyPair {
-	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneEdgePrefix+namespace, certificates.LegacyFakeDnsName)
+	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneEdgeName(namespace), certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 	return kp
 }
 
-func mustCreateDataPlanePipelineCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, pipelineId string) *certificates.KeyPair {
-	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlanePipelinePrefix+pipelineId, certificates.LegacyFakeDnsName)
+func mustCreateDataPlaneRoutingCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, routingId string) *certificates.KeyPair {
+	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.DataPlaneRoutingName(routingId), certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 	return kp
 }

--- a/pkg/certificates/reconciler/certificates_test.go
+++ b/pkg/certificates/reconciler/certificates_test.go
@@ -381,7 +381,7 @@ func mustCreateDataPlaneRoutingCert(t *testing.T, expirationInterval time.Durati
 }
 
 func mustCreateControlPlaneCert(t *testing.T, expirationInterval time.Duration, caKey *rsa.PrivateKey, caCertificate *x509.Certificate) *certificates.KeyPair {
-	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.ControlPlaneName)
+	kp, err := certificates.CreateCert(context.TODO(), caKey, caCertificate, expirationInterval, certificates.ControlPlaneName, certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 	return kp
 }

--- a/pkg/certificates/reconciler/controller.go
+++ b/pkg/certificates/reconciler/controller.go
@@ -38,6 +38,7 @@ import (
 const (
 	caSecretNamePostfix    = "-ctrl-ca"
 	secretLabelNamePostfix = "-ctrl"
+	secretRoutingId        = "routing-id"
 )
 
 // NewControllerFactory generates a ControllerConstructor for the control certificates reconciler.

--- a/pkg/network/tls.go
+++ b/pkg/network/tls.go
@@ -33,7 +33,10 @@ func LoadServerTLSConfigFromFile() (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    certPool,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ServerName:   "knative-myns",
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			err := cs.PeerCertificates[0].VerifyHostname(certificates.ControlPlaneName)
+			return err
+		},
 	}
 
 	return conf, nil

--- a/pkg/network/tls.go
+++ b/pkg/network/tls.go
@@ -34,7 +34,7 @@ func LoadServerTLSConfigFromFile() (*tls.Config, error) {
 		ClientCAs:    certPool,
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		VerifyConnection: func(cs tls.ConnectionState) error {
-			err := cs.PeerCertificates[0].VerifyHostname(certificates.ControlPlaneName)
+			err := cs.PeerCertificates[0].VerifyHostname(certificates.DataPlaneRoutingName(""))
 			return err
 		},
 	}
@@ -58,7 +58,7 @@ func LoadClientTLSConfigFromFile() (*tls.Config, error) {
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      certPool,
-		ServerName:   "knative-myns",
+		ServerName:   certificates.DataPlaneEdgeName("myns"),
 	}
 
 	return conf, nil

--- a/pkg/network/tls.go
+++ b/pkg/network/tls.go
@@ -58,7 +58,7 @@ func LoadClientTLSConfigFromFile() (*tls.Config, error) {
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      certPool,
-		ServerName:   certificates.DataPlaneEdgeName("myns"),
+		ServerName:   certificates.DataPlaneUserName("myns"),
 	}
 
 	return conf, nil

--- a/pkg/reconciler/tls_dialer_factory.go
+++ b/pkg/reconciler/tls_dialer_factory.go
@@ -70,7 +70,7 @@ func (ch *ListerCertificateGetter) GenerateTLSDialer(baseDialOptions *net.Dialer
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{controlPlaneCert},
 		RootCAs:      certPool,
-		ServerName:   certificates.DataPlaneEdgeName(ch.namespace),
+		ServerName:   certificates.DataPlaneUserName(ch.namespace),
 	}
 
 	// Copy from base dial options

--- a/pkg/reconciler/tls_dialer_factory.go
+++ b/pkg/reconciler/tls_dialer_factory.go
@@ -70,7 +70,7 @@ func (ch *ListerCertificateGetter) GenerateTLSDialer(baseDialOptions *net.Dialer
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{controlPlaneCert},
 		RootCAs:      certPool,
-		ServerName:   certificates.DataPlaneNamePrefix + ch.namespace,
+		ServerName:   certificates.DataPlaneEdgePrefix + ch.namespace,
 	}
 
 	// Copy from base dial options

--- a/pkg/reconciler/tls_dialer_factory.go
+++ b/pkg/reconciler/tls_dialer_factory.go
@@ -70,7 +70,7 @@ func (ch *ListerCertificateGetter) GenerateTLSDialer(baseDialOptions *net.Dialer
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{controlPlaneCert},
 		RootCAs:      certPool,
-		ServerName:   certificates.DataPlaneEdgePrefix + ch.namespace,
+		ServerName:   certificates.DataPlaneEdgeName(ch.namespace),
 	}
 
 	// Copy from base dial options

--- a/pkg/reconciler/tls_dialer_factory_test.go
+++ b/pkg/reconciler/tls_dialer_factory_test.go
@@ -42,7 +42,7 @@ func TestListerCertificateGetter_GenerateTLSDialer(t *testing.T) {
 	caCert, caPrivate, err := caKP.Parse()
 	require.NoError(t, err)
 
-	kp, err := certificates.CreateCert(context.TODO(), caPrivate, caCert, 24*time.Hour, certificates.DataPlaneEdgeName(namespace), certificates.LegacyFakeDnsName)
+	kp, err := certificates.CreateCert(context.TODO(), caPrivate, caCert, 24*time.Hour, certificates.DataPlaneUserName(namespace), certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 
 	secretData := make(map[string][]byte)

--- a/pkg/reconciler/tls_dialer_factory_test.go
+++ b/pkg/reconciler/tls_dialer_factory_test.go
@@ -42,7 +42,7 @@ func TestListerCertificateGetter_GenerateTLSDialer(t *testing.T) {
 	caCert, caPrivate, err := caKP.Parse()
 	require.NoError(t, err)
 
-	kp, err := certificates.CreateCert(context.TODO(), caPrivate, caCert, 24*time.Hour, certificates.DataPlaneEdgePrefix+namespace, certificates.LegacyFakeDnsName)
+	kp, err := certificates.CreateCert(context.TODO(), caPrivate, caCert, 24*time.Hour, certificates.DataPlaneEdgeName(namespace), certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 
 	secretData := make(map[string][]byte)

--- a/pkg/reconciler/tls_dialer_factory_test.go
+++ b/pkg/reconciler/tls_dialer_factory_test.go
@@ -42,7 +42,7 @@ func TestListerCertificateGetter_GenerateTLSDialer(t *testing.T) {
 	caCert, caPrivate, err := caKP.Parse()
 	require.NoError(t, err)
 
-	kp, err := certificates.CreateCert(context.TODO(), caPrivate, caCert, 24*time.Hour, certificates.DataPlaneNamePrefix+namespace, certificates.LegacyFakeDnsName)
+	kp, err := certificates.CreateCert(context.TODO(), caPrivate, caCert, 24*time.Hour, certificates.DataPlaneEdgePrefix+namespace, certificates.LegacyFakeDnsName)
 	require.NoError(t, err)
 
 	secretData := make(map[string][]byte)

--- a/pkg/test/tls.go
+++ b/pkg/test/tls.go
@@ -52,16 +52,16 @@ func MustGenerateTestTLSConf(t *testing.T, ctx context.Context) (func() (*tls.Co
 
 func mustGenerateTLSServerConf(t *testing.T, ctx context.Context, caKey *rsa.PrivateKey, caCertificate *x509.Certificate, namespace string) func() (*tls.Config, error) {
 	return func() (*tls.Config, error) {
-		dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caKey, caCertificate, 24*time.Hour, certificates.DataPlaneEdgeName(namespace), certificates.LegacyFakeDnsName)
+		dataPlaneUserKeyPair, err := certificates.CreateCert(ctx, caKey, caCertificate, 24*time.Hour, certificates.DataPlaneUserName(namespace), certificates.LegacyFakeDnsName)
 		require.NoError(t, err)
 
-		dataPlaneEdgeCert, err := tls.X509KeyPair(dataPlaneEdgeKeyPair.CertBytes(), dataPlaneEdgeKeyPair.PrivateKeyBytes())
+		dataPlaneUserCert, err := tls.X509KeyPair(dataPlaneUserKeyPair.CertBytes(), dataPlaneUserKeyPair.PrivateKeyBytes())
 		require.NoError(t, err)
 
 		certPool := x509.NewCertPool()
 		certPool.AddCert(caCertificate)
 		return &tls.Config{
-			Certificates: []tls.Certificate{dataPlaneEdgeCert},
+			Certificates: []tls.Certificate{dataPlaneUserCert},
 			ClientCAs:    certPool,
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			VerifyConnection: func(cs tls.ConnectionState) error {
@@ -84,6 +84,6 @@ func mustGenerateTLSClientConf(t *testing.T, ctx context.Context, caKey *rsa.Pri
 	return &tls.Config{
 		Certificates: []tls.Certificate{dataPlaneRoutingCert},
 		RootCAs:      certPool,
-		ServerName:   certificates.DataPlaneEdgeName(namespace),
+		ServerName:   certificates.DataPlaneUserName(namespace),
 	}
 }

--- a/pkg/test/tls.go
+++ b/pkg/test/tls.go
@@ -64,6 +64,10 @@ func mustGenerateTLSServerConf(t *testing.T, ctx context.Context, caKey *rsa.Pri
 			Certificates: []tls.Certificate{dataPlaneCert},
 			ClientCAs:    certPool,
 			ClientAuth:   tls.RequireAndVerifyClientCert,
+			VerifyConnection: func(cs tls.ConnectionState) error {
+				err := cs.PeerCertificates[0].VerifyHostname(certificates.ControlPlaneName)
+				return err
+			},
 		}, nil
 	}
 }

--- a/test/conformance/feature/conformance_feature.go
+++ b/test/conformance/feature/conformance_feature.go
@@ -65,7 +65,7 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 			dataPlaneRoutingKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneRoutingName(""), certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
-			dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneEdgeName("myns"), certificates.LegacyFakeDnsName)
+			dataPlaneUserKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneUserName("myns"), certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
 			// Create the secrets
@@ -86,8 +86,8 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 					Namespace: environment.FromContext(ctx).Namespace(),
 				},
 				Data: map[string][]byte{
-					certificates.SecretCertKey:   dataPlaneEdgeKeyPair.CertBytes(),
-					certificates.SecretPKKey:     dataPlaneEdgeKeyPair.PrivateKeyBytes(),
+					certificates.SecretCertKey:   dataPlaneUserKeyPair.CertBytes(),
+					certificates.SecretPKKey:     dataPlaneUserKeyPair.PrivateKeyBytes(),
 					certificates.SecretCaCertKey: caKP.CertBytes(),
 				},
 			}

--- a/test/conformance/feature/conformance_feature.go
+++ b/test/conformance/feature/conformance_feature.go
@@ -62,10 +62,10 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 			caCert, caPrivateKey, err := caKP.Parse()
 			require.NoError(t, err)
 
-			dataPlanePipelineKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlanePipelinePrefix+"0", certificates.LegacyFakeDnsName)
+			dataPlaneRoutingKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneRoutingName(""), certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
-			dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneEdgePrefix+environment.FromContext(ctx).Namespace(), certificates.LegacyFakeDnsName)
+			dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneEdgeName("myns"), certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
 			// Create the secrets
@@ -75,8 +75,8 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 					Namespace: environment.FromContext(ctx).Namespace(),
 				},
 				Data: map[string][]byte{
-					certificates.SecretCertKey:   dataPlanePipelineKeyPair.CertBytes(),
-					certificates.SecretPKKey:     dataPlanePipelineKeyPair.PrivateKeyBytes(),
+					certificates.SecretCertKey:   dataPlaneRoutingKeyPair.CertBytes(),
+					certificates.SecretPKKey:     dataPlaneRoutingKeyPair.PrivateKeyBytes(),
 					certificates.SecretCaCertKey: caKP.CertBytes(),
 				},
 			}

--- a/test/conformance/feature/conformance_feature.go
+++ b/test/conformance/feature/conformance_feature.go
@@ -62,10 +62,10 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 			caCert, caPrivateKey, err := caKP.Parse()
 			require.NoError(t, err)
 
-			dataPlanePipelineKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlanePipelinePrefix+"myns", certificates.LegacyFakeDnsName)
+			dataPlanePipelineKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlanePipelinePrefix+"0", certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
-			dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneEdgePrefix+"myns", certificates.LegacyFakeDnsName)
+			dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneEdgePrefix+environment.FromContext(ctx).Namespace(), certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
 			// Create the secrets

--- a/test/conformance/feature/conformance_feature.go
+++ b/test/conformance/feature/conformance_feature.go
@@ -62,10 +62,10 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 			caCert, caPrivateKey, err := caKP.Parse()
 			require.NoError(t, err)
 
-			controlPlaneKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneNamePrefix+"myns", certificates.LegacyFakeDnsName)
+			dataPlanePipelineKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlanePipelinePrefix+"myns", certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
-			dataPlaneKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneNamePrefix+"myns", certificates.LegacyFakeDnsName)
+			dataPlaneEdgeKeyPair, err := certificates.CreateCert(ctx, caPrivateKey, caCert, 24*time.Hour, certificates.DataPlaneEdgePrefix+"myns", certificates.LegacyFakeDnsName)
 			require.NoError(t, err)
 
 			// Create the secrets
@@ -75,8 +75,8 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 					Namespace: environment.FromContext(ctx).Namespace(),
 				},
 				Data: map[string][]byte{
-					certificates.SecretCertKey:   controlPlaneKeyPair.CertBytes(),
-					certificates.SecretPKKey:     controlPlaneKeyPair.PrivateKeyBytes(),
+					certificates.SecretCertKey:   dataPlanePipelineKeyPair.CertBytes(),
+					certificates.SecretPKKey:     dataPlanePipelineKeyPair.PrivateKeyBytes(),
 					certificates.SecretCaCertKey: caKP.CertBytes(),
 				},
 			}
@@ -86,8 +86,8 @@ func conformanceFeature(featureName string, tls bool) *feature.Feature {
 					Namespace: environment.FromContext(ctx).Namespace(),
 				},
 				Data: map[string][]byte{
-					certificates.SecretCertKey:   dataPlaneKeyPair.CertBytes(),
-					certificates.SecretPKKey:     dataPlaneKeyPair.PrivateKeyBytes(),
+					certificates.SecretCertKey:   dataPlaneEdgeKeyPair.CertBytes(),
+					certificates.SecretPKKey:     dataPlaneEdgeKeyPair.PrivateKeyBytes(),
 					certificates.SecretCaCertKey: caKP.CertBytes(),
 				},
 			}


### PR DESCRIPTION
In this PR we add support for separate certificates to:
 -  Control (Autoscaler etc.)
 - Data Routing (Ingress GW, Activator)
 - Data User (Queue etc.)

Also added some name-fixing and Deprecation notices on deprecated public items